### PR TITLE
fix(hpc4): eduroam NAT (10.79/16) + NordVPN 環境での HKUST 圏外誤判定を修正 (close #2)

### DIFF
--- a/.claude/skills/hpc4/scripts/common.sh
+++ b/.claude/skills/hpc4/scripts/common.sh
@@ -61,13 +61,55 @@ iface_has_hkust_ip() {
     ifconfig "$1" 2>/dev/null | awk '/inet 143\.89\./{found=1} END{exit !found}'
 }
 
-# 全 IF を走査して 143.89/16 IPv4 を持つ最初の IF 名を返す（無ければ空文字）。
+# 与えた IF が HKUST 到達能力を持つか。
+# (1) 143.89/16 IP を直接保持（HKUST VPN / 有線）
+# (2) eduroam NAT: private IP を持ち、routing table に 143.89.x → この IF の host route が存在
+# (3) HKUST eduroam 特有の 10.79/16 IP を保持
+iface_is_hkust_capable() {
+    [[ -n "${1:-}" ]] || return 1
+    ifconfig "$1" 2>/dev/null | awk '/inet 143\.89\./{found=1} END{exit !found}' && return 0
+    ifconfig "$1" 2>/dev/null | grep -qE 'inet (10\.|192\.168\.)' || return 1
+    netstat -rn 2>/dev/null | awk -v iface="$1" \
+        '$NF==iface && /^143\.89\./{found=1} END{exit !found}' && return 0
+    ifconfig "$1" 2>/dev/null | grep -q 'inet 10\.79\.'
+}
+
+# 全 IF を走査して HKUST 到達能力を持つ最初の IF 名を返す（無ければ空文字）。
 # routing table と独立に「この Mac には HKUST 圏に届く能力があるか」を判定する。
 # stale な host pin が route get の結果を歪めても、これは騙されない。
+#
+# 判定順:
+#   (1) 143.89/16 IP を直接持つ IF（HKUST VPN / 有線）
+#   (2) routing table に「143.89.x → private GW 経由で物理 IF」が存在（eduroam NAT + 既存 host route）
+#   (3) route get が physical IF を返し、その IF が private IP を持つ（NordVPN が default を奪っていない場合）
+#   (4) HKUST eduroam 特有の 10.79/16 IP を持つ物理 IF（最終手段）
 find_hkust_iface() {
-    ifconfig 2>/dev/null | awk '
+    local iface
+    iface=$(ifconfig 2>/dev/null | awk '
         /^[a-z]/ { iface=$1; sub(":", "", iface) }
         /inet 143\.89\./ { print iface; exit }
+    ')
+    [[ -n "$iface" ]] && { printf '%s' "$iface"; return 0; }
+
+    iface=$(netstat -rn 2>/dev/null | awk '
+        /^143\.89\./ &&
+        ($2 ~ /^10\./ || $2 ~ /^192\.168\./) &&
+        $NF ~ /^en/ { print $NF; exit }
+    ')
+    [[ -n "$iface" ]] && { printf '%s' "$iface"; return 0; }
+
+    local route_iface
+    route_iface=$(route get "$HPC4_IP" 2>/dev/null | awk '/interface:/{print $2}')
+    if [[ -n "$route_iface" ]] && [[ "$route_iface" =~ ^en ]]; then
+        if ifconfig "$route_iface" 2>/dev/null | grep -qE 'inet (10\.|192\.168\.)'; then
+            printf '%s' "$route_iface"
+            return 0
+        fi
+    fi
+
+    ifconfig 2>/dev/null | awk '
+        /^en/ { iface=$1; sub(":", "", iface) }
+        /inet 10\.79\./ { print iface; exit }
     '
 }
 

--- a/.claude/skills/hpc4/scripts/net-up.sh
+++ b/.claude/skills/hpc4/scripts/net-up.sh
@@ -19,19 +19,29 @@
 set -u
 source "$(dirname "$0")/common.sh"
 
-# --- (1) HKUST 圏内能力の有無を ifconfig だけで判定 ------------------------
-# routing table とは独立に「この Mac は 143.89/16 IP を持っているか」を見る。
-# stale な host pin が route get の判定を歪めても、ここは騙されない。
+# --- (0) TCP fast-path：TCP 22 が既に通れば routing は全て正常 ---------------
+# eduroam NAT (10.79/16) + NordVPN 同居など、IF 判定では捕捉しにくい構成でも
+# 実際に届いているなら診断をスキップして即 OK を返す。
+if tcp22_ok 3; then
+    ok "TCP 22 到達 OK（routing 判定スキップ）"
+    exit 0
+fi
+
+# --- (1) HKUST 圏内能力の有無を判定 ----------------------------------------
+# (a) 143.89/16 IP を直接持つ IF
+# (b) eduroam NAT (10.79/16) 経由で 143.89.x への route が既存
+# (c) route get が physical IF → private IP の場合（NordVPN なし）
+# (d) 10.79/16 IP を持つ物理 IF（HKUST eduroam NAT の特徴）
 hkust_iface="$(find_hkust_iface)"
 
 if [[ -z "$hkust_iface" ]]; then
-    err "あなたの Mac には 143.89/16 (HKUST) IPv4 を持つ IF が一つもありません。"
-    err "  → HKUST キャンパス内の eduroam または HKUST 有線（オンキャンパスの場合）"
+    err "あなたの Mac には HKUST 到達能力を持つ IF が一つもありません。"
+    err "  → HKUST キャンパス内の eduroam (10.79/16 NAT) または HKUST 有線（オンキャンパスの場合）"
     err "  → Ivanti Secure Access (HKUST SSL VPN) を起動（オフキャンパスの場合）"
     err ""
-    err "備考：eduroam は federated roaming service なので HKUST 以外（DT Hub 等の HKSTP"
-    err "      施設、他大学、空港）でも同じ SSID で繋がりますが、HKUST IP は降ってこず"
-    err "      HPC4 には届きません。詳細は .claude/skills/hpc4/policy.md。"
+    err "備考：eduroam は federated なので HKUST 以外（DT Hub 等の HKSTP 施設、他大学、空港）でも"
+    err "      同じ SSID で繋がりますが、HKUST 構成員向け eduroam でないと HPC4 に届きません。"
+    err "      詳細は .claude/skills/hpc4/policy.md。"
     exit 1
 fi
 
@@ -40,7 +50,7 @@ fi
 # 害悪な存在。delete を user に依頼する。
 existing_pin="$(current_hpc4_iface)"
 
-if [[ -n "$existing_pin" ]] && ! iface_has_hkust_ip "$existing_pin"; then
+if [[ -n "$existing_pin" ]] && ! iface_is_hkust_capable "$existing_pin"; then
     err "前回 set した HPC4 host route が ${existing_pin} (HKUST 圏外) を指したまま残っています。"
     err "longest-prefix-match でこの stale pin が natural route を上書きしてしまうので、削除が必要です。"
     err ""
@@ -58,7 +68,7 @@ fi
 resolve="$(hpc4_route_resolve)"
 egress="$(printf '%s' "$resolve" | awk '{print $1}')"
 
-if [[ -z "$egress" ]] || ! iface_has_hkust_ip "$egress"; then
+if [[ -z "$egress" ]] || ! iface_is_hkust_capable "$egress"; then
     err "HKUST 圏内 IF (${hkust_iface}) は存在しますが、kernel は HPC4 を別 IF (${egress:-なし}) に流しています。"
     err "host pin で ${hkust_iface} に固定する必要があります。別ターミナルで以下を 1 行実行してください："
     err ""

--- a/.claude/skills/hpc4/scripts/ssh-run.sh
+++ b/.claude/skills/hpc4/scripts/ssh-run.sh
@@ -14,7 +14,8 @@ if [[ $# -lt 1 ]]; then
 fi
 
 # ネットワーク層が未整備なら整備（既に届くならスキップ）
-if ! ping_ok 2; then
+# ICMP は eduroam でブロックされる場合があるため TCP 22 で到達確認する
+if ! tcp22_ok 3; then
     log "経路未整備。net-up.sh を実行"
     bash "$(dirname "$0")/net-up.sh" || exit $?
 fi

--- a/.claude/skills/hpc4/scripts/status.sh
+++ b/.claude/skills/hpc4/scripts/status.sh
@@ -27,21 +27,21 @@ fi
 hkust_iface="$(find_hkust_iface)"
 
 if [[ -z "$hkust_iface" ]]; then
-    printf "  [ng]   HKUST 圏内 IF なし：143.89/16 IPv4 を持つ IF が一つもありません\n"
-    printf "         → HKUST キャンパス内の eduroam または HKUST 有線（オンキャンパスの場合）\n"
+    printf "  [ng]   HKUST 到達能力なし：HKUST 圏内 IF が見つかりません\n"
+    printf "         → HKUST キャンパス内の eduroam (10.79/16 NAT) または HKUST 有線（オンキャンパスの場合）\n"
     printf "         → Ivanti Secure Access (HKUST SSL VPN) を起動（オフキャンパスの場合）\n"
     printf "         備考：eduroam は federated なので HKUST 外（DT Hub 等）でも繋がりますが\n"
-    printf "               HKUST IP は降りません。詳細は .claude/skills/hpc4/policy.md\n"
+    printf "               HKUST 構成員向け eduroam でないと HPC4 に届きません。詳細は .claude/skills/hpc4/policy.md\n"
     exit 0
 fi
 
-hkust_ip="$(ifconfig "$hkust_iface" 2>/dev/null | awk '/inet 143\.89\./{print $2; exit}')"
+hkust_ip="$(ifconfig "$hkust_iface" 2>/dev/null | awk '/inet (143\.89\.|10\.79\.)/{print $2; exit}')"
 printf "  [ok]   HKUST 圏内 IF：%s (IP=%s)\n" "$hkust_iface" "${hkust_ip:-?}"
 
 # --- (3) stale pin 検出 ----------------------------------------------------
 existing_pin="$(current_hpc4_iface)"
 
-if [[ -n "$existing_pin" ]] && ! iface_has_hkust_ip "$existing_pin"; then
+if [[ -n "$existing_pin" ]] && ! iface_is_hkust_capable "$existing_pin"; then
     printf "  [ng]   HPC4 host route：%s に固定済みだが HKUST 圏外（stale pin）\n" "$existing_pin"
     printf "         longest-prefix-match でこの pin が natural route を上書きしています\n"
     printf "         → 別ターミナルで sudo route -n delete -host %s を実行\n" "$HPC4_IP"
@@ -52,7 +52,7 @@ fi
 resolve="$(hpc4_route_resolve)"
 egress="$(printf '%s' "$resolve" | awk '{print $1}')"
 
-if [[ -z "$egress" ]] || ! iface_has_hkust_ip "$egress"; then
+if [[ -z "$egress" ]] || ! iface_is_hkust_capable "$egress"; then
     printf "  [ng]   HPC4 egress：%s（HKUST 圏外）\n" "${egress:-なし}"
     printf "         HKUST 圏内 IF (%s) はあるのに kernel が別 IF を選んでいます\n" "$hkust_iface"
     printf "         → 別ターミナルで sudo route -n add -host %s -interface %s を実行\n" "$HPC4_IP" "$hkust_iface"


### PR DESCRIPTION
Closes #2

## 変更概要

HKUST eduroam (NAT 10.79/16) + NordVPN 同居環境で `status.sh` / `net-up.sh` が「HKUST 圏外」と誤判定する問題を修正。

## 修正内容

### `common.sh`
- `find_hkust_iface` を4段階判定に拡張
  1. 143.89/16 IP を直接持つ IF（既存）
  2. routing table に「143.89.x → private GW 経由の物理 IF」が存在（eduroam + 既存 host route）
  3. `route get` が物理 IF を返し private IP を持つ（NordVPN が default を奪っていない場合）
  4. HKUST eduroam 特有の 10.79/16 IP を持つ物理 IF（最終手段）
- `iface_is_hkust_capable` を追加（`iface_has_hkust_ip` の eduroam 対応版）

### `net-up.sh`
- TCP fast-path を先頭に追加（TCP 22 が通れば IF 判定をスキップして exit 0）
- `iface_has_hkust_ip` → `iface_is_hkust_capable` に置換

### `status.sh`
- `iface_has_hkust_ip` → `iface_is_hkust_capable` に置換
- IP 表示を 10.79.x.x にも対応

### `ssh-run.sh`
- `ping_ok` → `tcp22_ok`（eduroam で ICMP がブロックされる場合に対応）

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ep1CcYXhuZjQEQ6exQeHp)_