### PR TITLE
fix(hpc4): sandbox 制限下の route/ping probe false negative を unknown 扱いにする (issue #3)

### DIFF
--- a/.claude/skills/hpc4/scripts/common.sh
+++ b/.claude/skills/hpc4/scripts/common.sh
@@ -131,6 +131,22 @@ ping_ok() {
     ping -c 2 -W "${t}000" "$HPC4_IP" >/dev/null 2>&1
 }
 
+# route socket が permission で塞がれているか。
+# Codex sandbox / 非 escalated 環境では `route -n get` / `ping` /
+# 一部 TCP probe が "Operation not permitted" を返し、実体は届いていても
+# 「経路欠落」と誤診断される。この helper はその false negative の入口を捕える。
+# 真なら呼出側は route 操作系（sudo route add 等）を促してはいけない。
+route_probe_restricted() {
+    local out
+    out=$(route -n get "$HPC4_IP" 2>&1)
+    case "$out" in
+        *"Operation not permitted"*) return 0 ;;
+        *"not permitted"*)           return 0 ;;
+        *"Permission denied"*)       return 0 ;;
+    esac
+    return 1
+}
+
 # --- SSH ラッパ用ヘルパ -----------------------------------------------------
 # macOS 既定 bash 3.2 互換のため mapfile / nameref は使わない
 

--- a/.claude/skills/hpc4/scripts/net-up.sh
+++ b/.claude/skills/hpc4/scripts/net-up.sh
@@ -15,6 +15,7 @@
 #   1  HKUST 圏内 IF が一つもない（network 状態を直す必要あり）
 #   2  L3 経路は OK だが TCP 22 不通（L4 遮断）
 #   3  user による sudo 操作が必要（stale pin 削除 or pin 追加）
+#   4  route socket が sandbox / permission で制限されており判定不能
 
 set -u
 source "$(dirname "$0")/common.sh"
@@ -25,6 +26,21 @@ source "$(dirname "$0")/common.sh"
 if tcp22_ok 3; then
     ok "TCP 22 到達 OK（routing 判定スキップ）"
     exit 0
+fi
+
+# --- (0.5) sandbox / permission 制限：route socket が塞がれているか ----------
+# Codex sandbox や非 escalated 環境では route get / ping / 一部 TCP probe が
+# 軒並み false negative になり、実際は届いているのに「経路欠落」と誤診断される。
+# この状態で sudo route add を促すと、(a) 操作自体が permission 拒否で失敗し、
+# (b) 実際には不要な route 追加を user に促してしまう。判定不能で即時終了する。
+if route_probe_restricted; then
+    err "route socket が制限されています（Codex sandbox / 非 escalated 環境の特徴）。"
+    err "この状態では route get / ping / 一部 TCP probe が実体と無関係に false negative"
+    err "を返すため、経路診断ができません。実際には HPC4 に届いている可能性があります。"
+    err ""
+    err "  → 別ターミナル（permission 制限のないシェル）で同じ script を再実行してください。"
+    err "    判定不能のまま sudo route add を勧めることはしません。"
+    exit 4
 fi
 
 # --- (1) HKUST 圏内能力の有無を判定 ----------------------------------------

--- a/.claude/skills/hpc4/scripts/ssh-run.sh
+++ b/.claude/skills/hpc4/scripts/ssh-run.sh
@@ -14,10 +14,17 @@ if [[ $# -lt 1 ]]; then
 fi
 
 # ネットワーク層が未整備なら整備（既に届くならスキップ）
-# ICMP は eduroam でブロックされる場合があるため TCP 22 で到達確認する
+# ICMP は eduroam でブロックされる場合があるため TCP 22 で到達確認する。
+# route socket が sandbox で制限されている場合は TCP probe が false negative
+# になり得るので、net-up.sh を呼ばず SSH を直接試行する（SSH 自体が成功すれば
+# 実体としては届いている）。
 if ! tcp22_ok 3; then
-    log "経路未整備。net-up.sh を実行"
-    bash "$(dirname "$0")/net-up.sh" || exit $?
+    if route_probe_restricted; then
+        log "route probe 制限を検出。net-up.sh をスキップして SSH を直接試行します"
+    else
+        log "経路未整備。net-up.sh を実行"
+        bash "$(dirname "$0")/net-up.sh" || exit $?
+    fi
 fi
 
 exec ssh "${HPC4_SSH_OPTS[@]}" -o BatchMode=yes hpc4 "$@"

--- a/.claude/skills/hpc4/scripts/status.sh
+++ b/.claude/skills/hpc4/scripts/status.sh
@@ -15,12 +15,27 @@ source "$(dirname "$0")/common.sh"
 
 printf "## HPC4 接続状態 (%s)\n" "$(date '+%F %T')"
 
+# Codex sandbox / 非 escalated 環境では route socket / ICMP / TCP probe が
+# 軒並み false negative になる。この flag が立つ場合、route 系の判定失敗は
+# [ng] ではなく [?] (sandbox restricted) として表示し、user に「不要な
+# sudo route add が必要」と誤認させない。
+restricted=0
+if route_probe_restricted; then
+    restricted=1
+fi
+
 # --- (1) 個人設定 -----------------------------------------------------------
 if [[ -f "$USER_CONF" ]] && [[ -n "${HPC4_USER:-}" ]] && [[ "$HPC4_USER" != "your_itso_username" ]]; then
     printf "  [ok]   user.conf.local 読み込み済み (HPC4_USER=%s, account=%s, partition=%s)\n" \
         "$HPC4_USER" "$HPC4_ACCOUNT" "$HPC4_PARTITION"
 else
     printf "  [err]  user.conf.local 未作成。bash .claude/skills/hpc4/scripts/write-user-conf.sh <itso_username> を実行してください\n"
+fi
+
+if (( restricted )); then
+    printf "  [?]    route socket 制限を検出（Codex sandbox / 非 escalated 環境の特徴）\n"
+    printf "         経路・疎通・SSH 認証の判定は false negative になり得るため [?] で表示します\n"
+    printf "         実際は HPC4 に届いている可能性があります。確実な判定は別ターミナルから\n"
 fi
 
 # --- (2) HKUST 圏内能力（routing と独立） ----------------------------------
@@ -53,13 +68,15 @@ resolve="$(hpc4_route_resolve)"
 egress="$(printf '%s' "$resolve" | awk '{print $1}')"
 
 if [[ -z "$egress" ]] || ! iface_is_hkust_capable "$egress"; then
-    printf "  [ng]   HPC4 egress：%s（HKUST 圏外）\n" "${egress:-なし}"
-    printf "         HKUST 圏内 IF (%s) はあるのに kernel が別 IF を選んでいます\n" "$hkust_iface"
-    printf "         → 別ターミナルで sudo route -n add -host %s -interface %s を実行\n" "$HPC4_IP" "$hkust_iface"
-    exit 0
-fi
-
-if [[ -n "$existing_pin" ]]; then
+    if (( restricted )); then
+        printf "  [?]    HPC4 egress：判定不能（route socket 制限）\n"
+    else
+        printf "  [ng]   HPC4 egress：%s（HKUST 圏外）\n" "${egress:-なし}"
+        printf "         HKUST 圏内 IF (%s) はあるのに kernel が別 IF を選んでいます\n" "$hkust_iface"
+        printf "         → 別ターミナルで sudo route -n add -host %s -interface %s を実行\n" "$HPC4_IP" "$hkust_iface"
+        exit 0
+    fi
+elif [[ -n "$existing_pin" ]]; then
     printf "  [ok]   HPC4 経路：%s 経由（host pin あり）\n" "$egress"
 else
     printf "  [ok]   HPC4 経路：%s 経由（kernel の自然な longest-prefix-match）\n" "$egress"
@@ -68,6 +85,8 @@ fi
 # --- (5) 疎通 ---------------------------------------------------------------
 if tcp22_ok 5; then
     printf "  [ok]   TCP 22 到達 OK\n"
+elif (( restricted )); then
+    printf "  [?]    TCP 22 疎通：判定不能（sandbox で probe が制限されている可能性）\n"
 else
     printf "  [ng]   TCP 22 不通：L3 経路は OK だが L4 で塞がれている\n"
     printf "         → bash .claude/skills/hpc4/scripts/net-up.sh で詳細診断\n"
@@ -79,6 +98,8 @@ fi
 if [[ -n "${HPC4_USER:-}" ]] && [[ "$HPC4_USER" != "your_itso_username" ]]; then
     if ssh_passwordless_ok; then
         printf "  [ok]   passwordless SSH 成立\n"
+    elif (( restricted )); then
+        printf "  [?]    passwordless SSH：判定不能（sandbox で BatchMode SSH が制限されている可能性）\n"
     else
         printf "  [ng]   passwordless SSH 未成立（公開鍵の登録が必要）\n"
         printf "         → ssh-copy-id -i ~/.ssh/id_ed25519.pub %s@%s （別ターミナルで一度だけ）\n" "$HPC4_USER" "$HPC4_HOST"


### PR DESCRIPTION
Fixes #3

## Summary
Codex sandbox / 非 escalated 環境では `route -n get` / `ping` / 一部 TCP probe が "Operation not permitted" や false negative を返し、実際は HPC4 に届いているのに「経路欠落」と誤診断され、不要な `sudo route add` に進む問題を修正。

## Changes
- **common.sh**: `route_probe_restricted()` helper を追加。`route -n get` の出力に "Operation not permitted" / "Permission denied" 等が含まれるかで sandbox 制限を検出する。
- **status.sh**: 制限を検出した場合、HPC4 egress / TCP 22 / passwordless SSH の判定失敗を `[ng]` ではなく `[?]` (sandbox restricted) として表示し、user に「実際は届いている可能性がある」と伝える。
- **net-up.sh**: 制限を検出した場合は exit 4 で即時終了。`sudo route add` を user に促さない（実際には不要であり、操作も permission 拒否で失敗する）。
- **ssh-run.sh**: 制限を検出した場合は `net-up.sh` を呼ばず SSH を直接試行する。TCP probe が false negative でも SSH 自体は成功する可能性がある。

## Test plan
- [ ] Codex sandbox 内で `bash scripts/status.sh` を実行し、egress / TCP 22 / SSH が `[?]` で表示されることを確認
- [ ] Codex sandbox 内で `bash scripts/net-up.sh` を実行し、`sudo route add` を促さず exit 4 で終了することを確認
- [ ] Codex sandbox 内で `bash scripts/ssh-run.sh "hostname"` が `net-up.sh` を経由せず SSH を直接試行することを確認
- [ ] 通常 terminal では従来通り [ng] / sudo 案内が出ることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWhc9Fj83bSxDhgZ4fSWak)_